### PR TITLE
Convert to character early

### DIFF
--- a/R/unite-str.R
+++ b/R/unite-str.R
@@ -25,6 +25,7 @@ unite_str <- function (data, col, ..., sep = ". ", remove = TRUE)
   else {
     from_vars <- tidyselect::eval_select(rlang::expr(c(...)), data)
   }
+  data <- dplyr::mutate(data, dplyr::across(tidyselect::all_of(from_vars), as.character))
   data <- dplyr::mutate(data, dplyr::across(tidyselect::all_of(from_vars), na_if_blank))
   data <- tidyr::unite(data, col = !!col, ..., sep = sep, remove = remove, na.rm = TRUE)
   data <- dplyr::mutate(data, dplyr::across(tidyselect::all_of(col), na_if_blank))


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`na_if()` now uses vctrs. It now converts `y` to the type of `x` to ensure that it is type stable. You have a test that is something like `na_if(<integer>, <character>)` which expects the output to be a character vector, but this is no longer allowed. Since it seems like you want this, I've added a line that converts to character early on.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!